### PR TITLE
Add Beautify button to editor toolbar

### DIFF
--- a/src/features/editor/TextEditor.tsx
+++ b/src/features/editor/TextEditor.tsx
@@ -3,6 +3,7 @@ import { LoadingOverlay } from "@mantine/core";
 import styled from "styled-components";
 import Editor, { type EditorProps, loader, type OnMount, useMonaco } from "@monaco-editor/react";
 import useConfig from "../../store/useConfig";
+import useEditor from "../../store/useEditor";
 import useFile from "../../store/useFile";
 
 loader.config({
@@ -30,6 +31,7 @@ const TextEditor = () => {
   const getHasChanges = useFile(state => state.getHasChanges);
   const theme = useConfig(state => (state.darkmodeEnabled ? "vs-dark" : "light"));
   const fileType = useFile(state => state.format);
+  const setEditorRef = useEditor(state => state.setEditorRef);
 
   React.useEffect(() => {
     monaco?.languages.json.jsonDefaults.setDiagnosticsOptions({
@@ -66,11 +68,15 @@ const TextEditor = () => {
     };
   }, [getHasChanges]);
 
-  const handleMount: OnMount = useCallback(editor => {
-    editor.onDidPaste(() => {
-      editor.getAction("editor.action.formatDocument")?.run();
-    });
-  }, []);
+  const handleMount: OnMount = useCallback(
+    editor => {
+      setEditorRef(editor);
+      editor.onDidPaste(() => {
+        editor.getAction("editor.action.formatDocument")?.run();
+      });
+    },
+    [setEditorRef]
+  );
 
   return (
     <StyledEditorWrapper>

--- a/src/features/editor/Toolbar/BeautifyButton.tsx
+++ b/src/features/editor/Toolbar/BeautifyButton.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { event as gaEvent } from "nextjs-google-analytics";
+import { IoCodeSlashOutline } from "react-icons/io5";
+import useEditor from "../../../store/useEditor";
+import { StyledToolElement } from "./styles";
+
+export const BeautifyButton = () => {
+  const editorRef = useEditor(state => state.editorRef);
+
+  const handleBeautify = () => {
+    if (editorRef) {
+      editorRef.getAction("editor.action.formatDocument")?.run();
+      gaEvent("beautify_document");
+    }
+  };
+
+  return (
+    <StyledToolElement title="Beautify" onClick={handleBeautify}>
+      <IoCodeSlashOutline size="18" />
+    </StyledToolElement>
+  );
+};

--- a/src/features/editor/Toolbar/index.tsx
+++ b/src/features/editor/Toolbar/index.tsx
@@ -9,6 +9,7 @@ import { type FileFormat, formats } from "../../../enums/file.enum";
 import { JSONCrackLogo } from "../../../layout/JsonCrackLogo";
 import useFile from "../../../store/useFile";
 import useModal from "../../../store/useModal";
+import { BeautifyButton } from "./BeautifyButton";
 import { FileMenu } from "./FileMenu";
 import { ToolsMenu } from "./ToolsMenu";
 import { ViewMenu } from "./ViewMenu";
@@ -83,6 +84,7 @@ export const Toolbar = ({ isWidget = false }: ToolbarProps) => {
           <FileMenu />
           <ViewMenu />
           <ToolsMenu />
+          <BeautifyButton />
         </Group>
       )}
       <Group gap="6" justify="right" w="100%" style={{ flexWrap: "nowrap" }}>

--- a/src/store/useEditor.ts
+++ b/src/store/useEditor.ts
@@ -1,0 +1,14 @@
+import type { OnMount } from "@monaco-editor/react";
+import { create } from "zustand";
+
+interface EditorState {
+  editorRef: Parameters<OnMount>[0] | null;
+  setEditorRef: (editor: Parameters<OnMount>[0]) => void;
+}
+
+const useEditor = create<EditorState>(set => ({
+  editorRef: null,
+  setEditorRef: editor => set({ editorRef: editor }),
+}));
+
+export default useEditor;


### PR DESCRIPTION
This PR adds a Beautify button to the editor toolbar that formats the document when clicked, similar to Postman's functionality.

Changes:
- Created a useEditor store to hold a reference to the Monaco editor instance
- Updated TextEditor to store the editor reference
- Added BeautifyButton component
- Added the button to the Toolbar component

The Beautify button formats the document using Monaco's built-in formatter when clicked.